### PR TITLE
Custom login page with Clerk Elements

### DIFF
--- a/docs/superpowers/plans/2026-04-11-custom-login-page.md
+++ b/docs/superpowers/plans/2026-04-11-custom-login-page.md
@@ -1,0 +1,326 @@
+# Custom Login Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the default Clerk `<SignIn />` widget with a custom split-layout login page using Clerk Elements, Google OAuth only.
+
+**Architecture:** Single file rewrite of `src/app/login/[[...sign-in]]/page.tsx`. Uses `@clerk/elements` headless primitives for the auth flow, `next/image` static imports for logo and background, and Tailwind for all styling. The existing middleware, ClerkProvider, and route structure remain untouched.
+
+**Tech Stack:** Next.js 16, React 19, @clerk/elements, @clerk/nextjs 6.39, Tailwind CSS 4, next/image
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `src/app/login/[[...sign-in]]/page.tsx` | Full rewrite — split layout with Clerk Elements Google OAuth |
+| None | `package.json` | `@clerk/elements` added via npm install |
+
+This is a single-file change. No new files created, no other files modified.
+
+---
+
+### Task 1: Install @clerk/elements
+
+**Files:**
+- Modify: `package.json` (via npm)
+
+- [ ] **Step 1: Install the package**
+
+Run:
+```bash
+npm install @clerk/elements
+```
+
+Expected: Package installs successfully. `@clerk/elements` appears in `package.json` dependencies.
+
+- [ ] **Step 2: Verify the install**
+
+Run:
+```bash
+npm ls @clerk/elements
+```
+
+Expected: Shows `@clerk/elements@<version>` in the dependency tree, no peer dependency warnings related to `@clerk/nextjs`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: install @clerk/elements for custom login page"
+```
+
+---
+
+### Task 2: Build the left branding panel
+
+Implement the left side of the split layout — background image, dark overlay, centered logo and branding text. No Clerk logic yet — just the visual shell.
+
+**Files:**
+- Modify: `src/app/login/[[...sign-in]]/page.tsx`
+
+- [ ] **Step 1: Replace the current login page with the split layout shell and left panel**
+
+Replace the entire contents of `src/app/login/[[...sign-in]]/page.tsx` with:
+
+```tsx
+'use client'
+
+import Image from 'next/image'
+import logoBlanc from '@/../public/logoBlanc.webp'
+import bgImage from '@/../public/accueil_valeur.png'
+
+export default function LoginPage() {
+  return (
+    <div className="min-h-screen flex flex-col lg:flex-row">
+      {/* Left Branding Panel */}
+      <div className="relative w-full lg:w-[45%] min-h-[240px] lg:min-h-screen overflow-hidden">
+        {/* Background image */}
+        <Image
+          src={bgImage}
+          alt=""
+          fill
+          priority
+          sizes="(max-width: 1024px) 100vw, 45vw"
+          placeholder="blur"
+          className="object-cover object-center"
+        />
+
+        {/* Dark overlay */}
+        <div className="absolute inset-0 bg-slate-900/70" />
+
+        {/* Brand-red accent bar */}
+        <div className="absolute top-0 left-0 w-full h-1 bg-brand-red z-10" />
+
+        {/* Centered content */}
+        <div className="relative z-10 h-full flex flex-col items-center justify-center px-8 py-12 text-center">
+          {/* Logo in frosted glass container */}
+          <div className="w-[72px] h-[72px] rounded-xl bg-white/10 backdrop-blur border border-white/10 flex items-center justify-center mb-7">
+            <Image
+              src={logoBlanc}
+              alt="Logo Les Gants Méléciens"
+              width={48}
+              height={48}
+              className="object-contain"
+            />
+          </div>
+
+          <p className="text-xs font-black uppercase tracking-widest text-brand-red mb-1">
+            Administration
+          </p>
+          <h1 className="text-2xl font-bold text-white leading-tight">
+            Les Gants<br />Méléciens
+          </h1>
+
+          <div className="w-15 h-px bg-white/10 my-4" />
+
+          <p className="text-xs text-white/45">
+            Système de Gestion Interne
+          </p>
+
+          {/* Footer — only visible on desktop */}
+          <p className="hidden lg:block absolute bottom-6 text-[9px] uppercase tracking-widest text-white/20">
+            &copy; {new Date().getFullYear()} Les Gants Méléciens
+          </p>
+        </div>
+      </div>
+
+      {/* Right Panel placeholder */}
+      <div className="flex-1 bg-slate-100 flex items-center justify-center p-12">
+        <p className="text-slate-400">Sign-in form goes here</p>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Run the dev server and verify visually**
+
+Run:
+```bash
+npm run dev
+```
+
+Open `http://localhost:3000/login` in the browser. Verify:
+- Split layout: left panel with background image, dark overlay, red accent bar, centered logo/branding
+- Right panel: slate-100 background with placeholder text
+- On mobile viewport: left panel stacks above as a short banner, right panel below
+- Logo renders inside the frosted glass container
+- "Administration" label is in brand-red
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/login/[[...sign-in]]/page.tsx
+git commit -m "feat: add split layout shell with left branding panel for login page"
+```
+
+---
+
+### Task 3: Build the right panel with Clerk Elements Google OAuth
+
+Add the Clerk Elements sign-in flow to the right panel — Google button, error state, loading state.
+
+**Files:**
+- Modify: `src/app/login/[[...sign-in]]/page.tsx`
+
+- [ ] **Step 1: Add Clerk Elements imports and replace the right panel placeholder**
+
+Update the imports at the top of `src/app/login/[[...sign-in]]/page.tsx`:
+
+```tsx
+'use client'
+
+import Image from 'next/image'
+import * as Clerk from '@clerk/elements/common'
+import * as SignIn from '@clerk/elements/sign-in'
+import logoBlanc from '@/../public/logoBlanc.webp'
+import bgImage from '@/../public/accueil_valeur.png'
+```
+
+Then replace the right panel placeholder (`<div className="flex-1 bg-slate-100 ...">...</div>`) with:
+
+```tsx
+      {/* Right Sign-In Panel */}
+      <div className="flex-1 bg-slate-100 flex items-center justify-center p-8 lg:p-12">
+        <SignIn.Root fallbackRedirectUrl="/admin/dashboard">
+          <SignIn.Step
+            name="start"
+            className="w-full max-w-[360px] text-center"
+          >
+            <h2 className="text-xl font-bold text-slate-900 mb-1">
+              Connexion
+            </h2>
+            <p className="text-sm text-slate-400 mb-8">
+              Connectez-vous pour accéder au panneau d&apos;administration
+            </p>
+
+            <Clerk.GlobalError className="mb-4 rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-600" />
+
+            <Clerk.Connection
+              name="google"
+              className="w-full flex items-center justify-center gap-3 rounded-xl bg-brand-red px-4 py-3.5 text-[15px] font-semibold text-white shadow-[0_2px_8px_rgba(223,6,6,0.25)] transition-colors hover:bg-red-700 active:bg-red-800"
+            >
+              <Clerk.Loading scope="provider:google">
+                {(isLoading) =>
+                  isLoading ? (
+                    <svg
+                      className="size-5 animate-spin text-white"
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                    >
+                      <circle
+                        className="opacity-25"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        strokeWidth="4"
+                      />
+                      <path
+                        className="opacity-75"
+                        fill="currentColor"
+                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                      />
+                    </svg>
+                  ) : (
+                    <>
+                      <svg
+                        className="size-5"
+                        viewBox="0 0 17 16"
+                        fill="none"
+                        aria-hidden
+                      >
+                        <path
+                          fill="currentColor"
+                          d="M8.82 7.28v2.187h5.227c-.16 1.226-.57 2.124-1.192 2.755-.764.765-1.955 1.6-4.035 1.6-3.218 0-5.733-2.595-5.733-5.813 0-3.218 2.515-5.814 5.733-5.814 1.733 0 3.005.685 3.938 1.565l1.538-1.538C12.998.96 11.256 0 8.82 0 4.41 0 .705 3.591.705 8s3.706 8 8.115 8c2.382 0 4.178-.782 5.582-2.24 1.44-1.44 1.893-3.475 1.893-5.111 0-.507-.035-.978-.115-1.369H8.82Z"
+                        />
+                      </svg>
+                      Continuer avec Google
+                    </>
+                  )
+                }
+              </Clerk.Loading>
+            </Clerk.Connection>
+
+            <p className="mt-10 text-[11px] text-slate-300">
+              Accès réservé aux administrateurs
+            </p>
+          </SignIn.Step>
+        </SignIn.Root>
+      </div>
+```
+
+- [ ] **Step 2: Run the dev server and verify the full page**
+
+Run:
+```bash
+npm run dev
+```
+
+Open `http://localhost:3000/login` in the browser. Verify:
+- Left panel: unchanged — branding, background image, overlay
+- Right panel: "Connexion" heading, subtitle, brand-red Google button with Google icon
+- Click the Google button: should redirect to Google OAuth flow (may fail in dev if Google OAuth not configured in Clerk dashboard — that's OK, verify the redirect initiates)
+- Loading state: button shows a spinner while the redirect is processing
+- "Accès réservé aux administrateurs" footer text visible below the button
+- Mobile: stacks vertically — short branding banner on top, Google button below
+
+- [ ] **Step 3: Verify error state**
+
+To test error rendering, you can temporarily force an error by trying to sign in with a Google account that is not in the Clerk allowlist (if applicable). The `Clerk.GlobalError` should display in a red-50 banner above the Google button.
+
+If you can't trigger an error easily, visually verify the `Clerk.GlobalError` element is present in the DOM (it renders empty when there's no error, which is correct).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/login/[[...sign-in]]/page.tsx
+git commit -m "feat: add Clerk Elements Google OAuth to custom login page"
+```
+
+---
+
+### Task 4: Final verification and cleanup
+
+**Files:**
+- None (verification only)
+
+- [ ] **Step 1: Build the project to check for type errors**
+
+Run:
+```bash
+npm run build
+```
+
+Expected: Build completes successfully with no type errors.
+
+- [ ] **Step 2: Run existing tests to check for regressions**
+
+Run:
+```bash
+npm test
+```
+
+Expected: All existing tests pass. No test changes needed since the login page had no tests before and we're not adding new routes or API logic.
+
+- [ ] **Step 3: Full manual verification**
+
+Open `http://localhost:3000/login` in the browser and check:
+1. Desktop — split layout renders correctly, left panel ~45%, right ~55%
+2. Mobile — stacks vertically, branding banner on top, form below
+3. Google button initiates OAuth flow on click
+4. After successful sign-in, redirects to `/admin/dashboard`
+5. Navigating to `/admin/dashboard` while unauthenticated redirects to `/login`
+6. After sign-in, the admin sidebar `UserButton` still works for sign-out
+7. Sign-out redirects back to `/login`
+
+- [ ] **Step 4: Commit if any adjustments were made**
+
+Only if changes were needed:
+```bash
+git add src/app/login/[[...sign-in]]/page.tsx
+git commit -m "fix: polish custom login page after final review"
+```

--- a/docs/superpowers/specs/2026-04-11-custom-login-page-design.md
+++ b/docs/superpowers/specs/2026-04-11-custom-login-page-design.md
@@ -22,11 +22,11 @@ Full-viewport-height split layout, two panels side by side.
 
 ### Left Panel (45% width)
 
-- **Background image:** Cloudinary-hosted training photo via `CldImage` (from `next-cloudinary`) — full cover (`object-cover`), positioned center. Asset publicId will be hardcoded/configured later.
+- **Background image:** Static import from `public/accueil_valeur.png` via `next/image` — full cover (`object-cover`), positioned center. Consistent with how the front-end handles static assets (Header.tsx, Footer.tsx).
 - **Dark overlay:** `bg-slate-900/70` on top of the image for text readability
 - **Brand-red accent bar:** 4px strip along the top edge, `#DF0606`
 - **Centered content (vertically and horizontally):**
-  - Club logo via `CldImage` — Cloudinary-hosted white logo, in a frosted glass container (`bg-white/10 backdrop-blur border border-white/10 rounded-xl`), ~72px. Asset publicId will be hardcoded/configured later.
+  - Club logo — static import from `public/logoBlanc.webp` via `next/image`, same pattern as Header.tsx. Displayed in a frosted glass container (`bg-white/10 backdrop-blur border border-white/10 rounded-xl`), ~72px.
   - "Administration" label — uppercase, tracking-widest, brand-red `#DF0606`
   - "Les Gants Meleciens" — large white heading
   - Thin separator line
@@ -87,7 +87,7 @@ With a new implementation using:
 - `Clerk.Connection name="google"` for the Google OAuth button
 - `Clerk.GlobalError` for error display
 - `Clerk.Loading` for loading states
-- `CldImage` from `next-cloudinary` for the background image and logo (Cloudinary assets assumed to be already uploaded — publicIds hardcoded/configured later)
+- `next/image` with static imports for the background image (`accueil_valeur.png`) and logo (`logoBlanc.webp`) — same pattern as the front-end Header/Footer
 
 ### Files NOT changed
 
@@ -133,8 +133,8 @@ Since this is Google OAuth only (no email/password), there are no verification s
 | Heading | `slate-900` | "Connexion" title |
 | Subtitle | `slate-400` | Descriptive text |
 | Logo container | `white/10` + `backdrop-blur` | Frosted glass effect |
-| Background image | Cloudinary asset (CldImage) | Left panel cover image — publicId TBD |
-| Logo | Cloudinary asset (CldImage) | White club logo — publicId TBD |
+| Background image | `public/accueil_valeur.png` | Left panel cover image (static import, `next/image`) |
+| Logo | `public/logoBlanc.webp` | White club logo (static import, `next/image`) |
 
 ## Scope
 

--- a/docs/superpowers/specs/2026-04-11-custom-login-page-design.md
+++ b/docs/superpowers/specs/2026-04-11-custom-login-page-design.md
@@ -22,11 +22,11 @@ Full-viewport-height split layout, two panels side by side.
 
 ### Left Panel (45% width)
 
-- **Background image:** `accueil_valeur.png` — full cover (`object-cover`), positioned center
+- **Background image:** Cloudinary-hosted training photo via `CldImage` (from `next-cloudinary`) — full cover (`object-cover`), positioned center. Asset publicId will be hardcoded/configured later.
 - **Dark overlay:** `bg-slate-900/70` on top of the image for text readability
 - **Brand-red accent bar:** 4px strip along the top edge, `#DF0606`
 - **Centered content (vertically and horizontally):**
-  - Club logo (`logoBlanc.webp`) in a frosted glass container (`bg-white/10 backdrop-blur border border-white/10 rounded-xl`), ~72px
+  - Club logo via `CldImage` — Cloudinary-hosted white logo, in a frosted glass container (`bg-white/10 backdrop-blur border border-white/10 rounded-xl`), ~72px. Asset publicId will be hardcoded/configured later.
   - "Administration" label — uppercase, tracking-widest, brand-red `#DF0606`
   - "Les Gants Meleciens" — large white heading
   - Thin separator line
@@ -87,7 +87,7 @@ With a new implementation using:
 - `Clerk.Connection name="google"` for the Google OAuth button
 - `Clerk.GlobalError` for error display
 - `Clerk.Loading` for loading states
-- `next/image` for the background image and logo
+- `CldImage` from `next-cloudinary` for the background image and logo (Cloudinary assets assumed to be already uploaded — publicIds hardcoded/configured later)
 
 ### Files NOT changed
 
@@ -133,8 +133,8 @@ Since this is Google OAuth only (no email/password), there are no verification s
 | Heading | `slate-900` | "Connexion" title |
 | Subtitle | `slate-400` | Descriptive text |
 | Logo container | `white/10` + `backdrop-blur` | Frosted glass effect |
-| Background image | `accueil_valeur.png` | Left panel cover image |
-| Logo | `logoBlanc.webp` | White club logo |
+| Background image | Cloudinary asset (CldImage) | Left panel cover image — publicId TBD |
+| Logo | Cloudinary asset (CldImage) | White club logo — publicId TBD |
 
 ## Scope
 

--- a/docs/superpowers/specs/2026-04-11-custom-login-page-design.md
+++ b/docs/superpowers/specs/2026-04-11-custom-login-page-design.md
@@ -1,0 +1,144 @@
+# Custom Login Page — Design Spec
+
+## Summary
+
+Replace the default Clerk `<SignIn />` widget on the login page with a custom-built split layout using **Clerk Elements** (`@clerk/elements`). The page should feel like a native part of the admin section, not an external service. Google OAuth is the sole sign-in method. No sign-up flow.
+
+## Motivation
+
+The current login page at `/login` renders Clerk's pre-built `<SignIn />` component, which looks like an embedded third-party widget. The goal is full visual cohesion with the admin design language (slate tones, brand-red `#DF0606`, uppercase tracking labels) while keeping Clerk as the auth provider with minimal custom auth logic.
+
+## Approach
+
+**Clerk Elements** — headless UI primitives from `@clerk/elements`. We build the layout and styling entirely in Tailwind; Clerk manages the OAuth flow, session creation, error handling, and redirects behind the scenes.
+
+Why this over alternatives:
+- `appearance` prop on `<SignIn />`: can't achieve a split layout or full design control.
+- `useSignIn()` hook: same visual result but requires manual OAuth redirect handling and error plumbing. Unnecessary complexity.
+
+## Layout
+
+Full-viewport-height split layout, two panels side by side.
+
+### Left Panel (45% width)
+
+- **Background image:** `accueil_valeur.png` — full cover (`object-cover`), positioned center
+- **Dark overlay:** `bg-slate-900/70` on top of the image for text readability
+- **Brand-red accent bar:** 4px strip along the top edge, `#DF0606`
+- **Centered content (vertically and horizontally):**
+  - Club logo (`logoBlanc.webp`) in a frosted glass container (`bg-white/10 backdrop-blur border border-white/10 rounded-xl`), ~72px
+  - "Administration" label — uppercase, tracking-widest, brand-red `#DF0606`
+  - "Les Gants Meleciens" — large white heading
+  - Thin separator line
+  - "Systeme de Gestion Interne" — subtle white/45% subtitle
+- **Footer:** copyright line at the bottom, very low opacity
+
+### Right Panel (55% width)
+
+- **Background:** `slate-100` (`#f1f5f9`)
+- **Centered content:**
+  - "Connexion" heading — `text-xl font-bold text-slate-900`
+  - Subtitle — "Connectez-vous pour acceder au panneau d'administration" in `text-slate-400`
+  - **Google sign-in button:** full-width, brand-red `#DF0606` background, white text + white Google icon, rounded-xl, subtle red shadow (`shadow-brand-red/25`)
+  - "Acces reserve aux administrateurs" — small muted footer text
+- **Error state:** `<Clerk.GlobalError>` renders in a red-50 banner below the button when auth fails
+- **Loading state:** `<Clerk.Loading>` shows a spinner inside the button during OAuth redirect
+
+### Mobile Responsiveness
+
+- On small screens, the split layout stacks vertically
+- Left panel becomes a short banner (reduced height, logo + club name only)
+- Right panel takes full width below with the Google button
+
+## Technical Details
+
+### New dependency
+
+- `@clerk/elements` — install alongside existing `@clerk/nextjs`
+
+### Files changed
+
+**`src/app/login/[[...sign-in]]/page.tsx`** — the only file that changes. Replace the current implementation:
+
+```tsx
+// CURRENT (will be replaced)
+import { SignIn } from "@clerk/nextjs";
+export default function LoginPage() {
+  return (
+    <div className="min-h-screen bg-slate-50 flex items-center justify-center">
+      <div className="flex flex-col items-center gap-8">
+        <div className="text-center">
+          <h1 className="text-sm font-black uppercase tracking-widest text-slate-400">Administration</h1>
+          <p className="text-2xl font-bold text-slate-900">Les Gants Meleciens</p>
+        </div>
+        <SignIn afterSignInUrl="/admin/dashboard" />
+      </div>
+    </div>
+  );
+}
+```
+
+With a new implementation using:
+- `'use client'` directive (Clerk Elements requires client components)
+- `import * as Clerk from '@clerk/elements/common'`
+- `import * as SignIn from '@clerk/elements/sign-in'`
+- `SignIn.Root` wrapping the page
+- `SignIn.Step name="start"` as the sole step
+- `Clerk.Connection name="google"` for the Google OAuth button
+- `Clerk.GlobalError` for error display
+- `Clerk.Loading` for loading states
+- `next/image` for the background image and logo
+
+### Files NOT changed
+
+- `src/proxy.ts` (middleware) — unchanged, still protects `/admin/*` routes
+- `src/app/layout.tsx` — unchanged, `ClerkProvider` stays as-is
+- `src/app/admin/_components/AdminSidebar.tsx` — unchanged, `UserButton` stays
+- Route structure (`/login/[[...sign-in]]`) — unchanged
+
+### Clerk Elements components used
+
+| Component | Purpose |
+|---|---|
+| `SignIn.Root` | Wraps the entire sign-in flow |
+| `SignIn.Step name="start"` | The initial (and only) step |
+| `Clerk.Connection name="google"` | Renders the Google OAuth button trigger |
+| `Clerk.GlobalError` | Displays auth errors (e.g. account not found) |
+| `Clerk.Loading` | Conditional rendering for loading states |
+
+### Post-sign-in redirect
+
+The current `<SignIn afterSignInUrl="/admin/dashboard" />` prop doesn't exist on Clerk Elements. Use `SignIn.Root`'s `fallbackRedirectUrl="/admin/dashboard"` prop instead. This redirects to `/admin/dashboard` after successful sign-in when no other redirect URL is pending (e.g. if the user was redirected from a specific admin page, they'll go back there instead).
+
+### Auth flow
+
+1. User visits `/login` (or gets redirected there by middleware when accessing `/admin/*`)
+2. Custom page renders with the split layout
+3. User clicks "Continuer avec Google"
+4. Clerk handles the OAuth redirect to Google and back
+5. On success, Clerk creates a session and redirects to the originally requested URL (or `/admin/dashboard` as fallback)
+6. On failure, `Clerk.GlobalError` displays the error message
+
+### No additional steps needed
+
+Since this is Google OAuth only (no email/password), there are no verification steps, no password strategy, no forgot-password flow. The `SignIn.Step name="start"` with `Clerk.Connection name="google"` is the entire flow.
+
+## Design Tokens
+
+| Token | Value | Usage |
+|---|---|---|
+| Brand red | `#DF0606` / `brand-red` | Accent bar, "Administration" label, Google button |
+| Left panel overlay | `slate-900/70` | Over background image |
+| Right panel bg | `slate-100` (`#f1f5f9`) | Form panel background |
+| Heading | `slate-900` | "Connexion" title |
+| Subtitle | `slate-400` | Descriptive text |
+| Logo container | `white/10` + `backdrop-blur` | Frosted glass effect |
+| Background image | `accueil_valeur.png` | Left panel cover image |
+| Logo | `logoBlanc.webp` | White club logo |
+
+## Scope
+
+- One new package (`@clerk/elements`)
+- One file rewritten (`src/app/login/[[...sign-in]]/page.tsx`)
+- No new routes, no new API endpoints, no database changes
+- No changes to the auth flow logic — Clerk still handles everything

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-s3": "^3.998.0",
+        "@clerk/elements": "^0.24.14",
         "@clerk/nextjs": "^6.39.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/helpers": "^0.3.2",
@@ -1149,12 +1150,12 @@
       }
     },
     "node_modules/@clerk/clerk-react": {
-      "version": "5.61.3",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.3.tgz",
-      "integrity": "sha512-W21aNEeHtqh3xJLuW5g2ydben/1D5pSnxsl/kCnv0IY1zma7lO+aIJ7Br2bR4FKKkiu695mPnjtY+fvkQmCXBg==",
+      "version": "5.61.4",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.4.tgz",
+      "integrity": "sha512-xGvQvzfc5pQEuqCW8CNUgnlR+9nt6gSSMGMYx3l972utIJrFKByQJFCRZpwYBvAHiveuK11Wgy3J39p904jb+w==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.47.2",
+        "@clerk/shared": "^3.47.3",
         "tslib": "2.8.1"
       },
       "engines": {
@@ -1163,6 +1164,38 @@
       "peerDependencies": {
         "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
         "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      }
+    },
+    "node_modules/@clerk/elements": {
+      "version": "0.24.14",
+      "resolved": "https://registry.npmjs.org/@clerk/elements/-/elements-0.24.14.tgz",
+      "integrity": "sha512-CLDrCn1s365cY4WIznSUDpYa9lodSBSLHc0lZ4bY9IYz8znmeGyLvwimMakK4WvIQzrv0LkETS96FY2Ic12Yew==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/clerk-react": "^5.61.4",
+        "@clerk/shared": "^3.47.3",
+        "@clerk/types": "^4.101.21",
+        "@radix-ui/primitive": "^1.1.3",
+        "@radix-ui/react-form": "^0.1.8",
+        "@radix-ui/react-slot": "^1.2.3",
+        "@xstate/react": "^6.0.0",
+        "client-only": "^0.0.1",
+        "tslib": "2.8.1",
+        "type-fest": "^4.41.0",
+        "xstate": "^5.20.2"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "next": "^13.5.7 || ^14.2.25 || ^15.2.3 || ^16",
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      },
+      "peerDependenciesMeta": {
+        "next": {
+          "optional": true
+        }
       }
     },
     "node_modules/@clerk/nextjs": {
@@ -1188,9 +1221,9 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "3.47.2",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.2.tgz",
-      "integrity": "sha512-dwUT27DKq3Gr9vn9lAfc/LSe79P1rKIib8/mTWA7ZEzY7XX2Yq5UnDMCMznYrI8oVLdJrCT4ypFXRgnH306Oew==",
+      "version": "3.47.3",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.3.tgz",
+      "integrity": "sha512-jG0wMIZuuc8zaKieg9Os8ocTphG+llluRukUUdyVnu4+ZI1syVf+dkpDP3ZK69yLavTX3D0KAmkmQqTPzQV/Nw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1224,12 +1257,12 @@
       "license": "MIT"
     },
     "node_modules/@clerk/types": {
-      "version": "4.101.20",
-      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.20.tgz",
-      "integrity": "sha512-MHvr1tGL5lwxD6zdzzixkHICbbZz/S1LChONKR52Qeu0yRGChZomPknsgqBMG9J3yNeyhaj0SWa5phQgQUk0lg==",
+      "version": "4.101.21",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.21.tgz",
+      "integrity": "sha512-/70W603A6bRv1n24dDNAs3kWHLSIgXebEyzXZ46IuROWcq0+guSqqLa+nKekxxIdk6I/vnI9SWjBvBRuZVMnhQ==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.47.2"
+        "@clerk/shared": "^3.47.3"
       },
       "engines": {
         "node": ">=18.17.0"
@@ -3185,6 +3218,185 @@
         "@types/react": "^18.0.0 || ^19.0.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-form": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.8.tgz",
+      "integrity": "sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-label": "2.1.7",
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@remirror/core-constants": {
@@ -5694,6 +5906,25 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@xstate/react": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@xstate/react/-/react-6.1.0.tgz",
+      "integrity": "sha512-ep9F0jGTI63B/jE8GHdMpUqtuz7yRebNaKv8EMUaiSi29NOglywc2X2YSOV/ygbIK+LtmgZ0q9anoEA2iBSEOw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.2",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "xstate": "^5.28.0"
+      },
+      "peerDependenciesMeta": {
+        "xstate": {
+          "optional": true
+        }
       }
     },
     "node_modules/acorn": {
@@ -10972,6 +11203,18 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "dev": true,
@@ -11179,6 +11422,20 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-sync-external-store": {
@@ -11580,6 +11837,16 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "license": "MIT"
+    },
+    "node_modules/xstate": {
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.30.0.tgz",
+      "integrity": "sha512-mIzIuMjtYVkqXq9dUzYQoag7b/dF1CBS/yhliuPLfR0FwKPC18HiUivb/crcqY2gknhR8gJEhnppLg6ubQ0gGw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/xstate"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.998.0",
+    "@clerk/elements": "^0.24.14",
     "@clerk/nextjs": "^6.39.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/helpers": "^0.3.2",

--- a/src/app/login/[[...sign-in]]/page.tsx
+++ b/src/app/login/[[...sign-in]]/page.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import Image from 'next/image'
+import * as Clerk from '@clerk/elements/common'
+import * as SignIn from '@clerk/elements/sign-in'
 import logoBlanc from '@/../public/logoBlanc.webp'
 import bgImage from '@/../public/accueil_valeur.png'
 
@@ -59,9 +61,74 @@ export default function LoginPage() {
         </div>
       </div>
 
-      {/* Right Panel placeholder */}
-      <div className="flex-1 bg-slate-100 flex items-center justify-center p-12">
-        <p className="text-slate-400">Sign-in form goes here</p>
+      {/* Right Sign-In Panel */}
+      <div className="flex-1 bg-slate-100 flex items-center justify-center p-8 lg:p-12">
+        <SignIn.Root fallbackRedirectUrl="/admin/dashboard">
+          <SignIn.Step
+            name="start"
+            className="w-full max-w-[360px] text-center"
+          >
+            <h2 className="text-xl font-bold text-slate-900 mb-1">
+              Connexion
+            </h2>
+            <p className="text-sm text-slate-400 mb-8">
+              Connectez-vous pour accéder au panneau d&apos;administration
+            </p>
+
+            <Clerk.GlobalError className="mb-4 rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-600" />
+
+            <Clerk.Connection
+              name="google"
+              className="w-full flex items-center justify-center gap-3 rounded-xl bg-brand-red px-4 py-3.5 text-[15px] font-semibold text-white shadow-[0_2px_8px_rgba(223,6,6,0.25)] transition-colors hover:bg-red-700 active:bg-red-800"
+            >
+              <Clerk.Loading scope="provider:google">
+                {(isLoading) =>
+                  isLoading ? (
+                    <svg
+                      className="size-5 animate-spin text-white"
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                    >
+                      <circle
+                        className="opacity-25"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        strokeWidth="4"
+                      />
+                      <path
+                        className="opacity-75"
+                        fill="currentColor"
+                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                      />
+                    </svg>
+                  ) : (
+                    <>
+                      <svg
+                        className="size-5"
+                        viewBox="0 0 17 16"
+                        fill="none"
+                        aria-hidden
+                      >
+                        <path
+                          fill="currentColor"
+                          d="M8.82 7.28v2.187h5.227c-.16 1.226-.57 2.124-1.192 2.755-.764.765-1.955 1.6-4.035 1.6-3.218 0-5.733-2.595-5.733-5.813 0-3.218 2.515-5.814 5.733-5.814 1.733 0 3.005.685 3.938 1.565l1.538-1.538C12.998.96 11.256 0 8.82 0 4.41 0 .705 3.591.705 8s3.706 8 8.115 8c2.382 0 4.178-.782 5.582-2.24 1.44-1.44 1.893-3.475 1.893-5.111 0-.507-.035-.978-.115-1.369H8.82Z"
+                        />
+                      </svg>
+                      Continuer avec Google
+                    </>
+                  )
+                }
+              </Clerk.Loading>
+            </Clerk.Connection>
+
+            <p className="mt-10 text-[11px] text-slate-300">
+              Accès réservé aux administrateurs
+            </p>
+          </SignIn.Step>
+        </SignIn.Root>
       </div>
     </div>
   )

--- a/src/app/login/[[...sign-in]]/page.tsx
+++ b/src/app/login/[[...sign-in]]/page.tsx
@@ -1,19 +1,68 @@
-import { SignIn } from "@clerk/nextjs";
+'use client'
+
+import Image from 'next/image'
+import logoBlanc from '@/../public/logoBlanc.webp'
+import bgImage from '@/../public/accueil_valeur.png'
 
 export default function LoginPage() {
   return (
-    <div className="min-h-screen bg-slate-50 flex items-center justify-center">
-      <div className="flex flex-col items-center gap-8">
-        <div className="text-center">
-          <h1 className="text-sm font-black uppercase tracking-widest text-slate-400">
+    <div className="min-h-screen flex flex-col lg:flex-row">
+      {/* Left Branding Panel */}
+      <div className="relative w-full lg:w-[45%] min-h-[240px] lg:min-h-screen overflow-hidden">
+        {/* Background image */}
+        <Image
+          src={bgImage}
+          alt=""
+          fill
+          priority
+          sizes="(max-width: 1024px) 100vw, 45vw"
+          placeholder="blur"
+          className="object-cover object-center"
+        />
+
+        {/* Dark overlay */}
+        <div className="absolute inset-0 bg-slate-900/70" />
+
+        {/* Brand-red accent bar */}
+        <div className="absolute top-0 left-0 w-full h-1 bg-brand-red z-10" />
+
+        {/* Centered content */}
+        <div className="relative z-10 h-full flex flex-col items-center justify-center px-8 py-12 text-center">
+          {/* Logo in frosted glass container */}
+          <div className="w-[72px] h-[72px] rounded-xl bg-white/10 backdrop-blur border border-white/10 flex items-center justify-center mb-7">
+            <Image
+              src={logoBlanc}
+              alt="Logo Les Gants Méléciens"
+              width={48}
+              height={48}
+              className="object-contain"
+            />
+          </div>
+
+          <p className="text-xs font-black uppercase tracking-widest text-brand-red mb-1">
             Administration
+          </p>
+          <h1 className="text-2xl font-bold text-white leading-tight">
+            Les Gants<br />Méléciens
           </h1>
-          <p className="text-2xl font-bold text-slate-900">
-            Les Gants Meleciens
+
+          <div className="w-15 h-px bg-white/10 my-4" />
+
+          <p className="text-xs text-white/45">
+            Système de Gestion Interne
+          </p>
+
+          {/* Footer — only visible on desktop */}
+          <p className="hidden lg:block absolute bottom-6 text-[9px] uppercase tracking-widest text-white/20">
+            &copy; {new Date().getFullYear()} Les Gants Méléciens
           </p>
         </div>
-        <SignIn afterSignInUrl="/admin/dashboard" />
+      </div>
+
+      {/* Right Panel placeholder */}
+      <div className="flex-1 bg-slate-100 flex items-center justify-center p-12">
+        <p className="text-slate-400">Sign-in form goes here</p>
       </div>
     </div>
-  );
+  )
 }

--- a/src/app/login/[[...sign-in]]/page.tsx
+++ b/src/app/login/[[...sign-in]]/page.tsx
@@ -63,7 +63,7 @@ export default function LoginPage() {
 
       {/* Right Sign-In Panel */}
       <div className="flex-1 bg-slate-100 flex items-center justify-center p-8 lg:p-12">
-        <SignIn.Root fallbackRedirectUrl="/admin/dashboard">
+        <SignIn.Root>
           <SignIn.Step
             name="start"
             className="w-full max-w-[360px] text-center"


### PR DESCRIPTION
## Summary

- Replace the default Clerk `<SignIn />` widget with a custom split-layout login page using **Clerk Elements** (`@clerk/elements`)
- Left panel: background image (`accueil_valeur.png`), dark overlay, club logo, branding — matches admin design language
- Right panel: single "Continuer avec Google" button in brand-red, with loading spinner and error handling
- Google OAuth only, no sign-up flow — admin access only
- Mobile responsive: stacks vertically on small screens

## Environment variable required

Add to `.env` (and deployment):
```
NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/admin/dashboard
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)